### PR TITLE
Corrige validação de campos de imagem nos DTOs de produto

### DIFF
--- a/api/src/modules/products/dto/create-product.dto.ts
+++ b/api/src/modules/products/dto/create-product.dto.ts
@@ -5,7 +5,6 @@ import {
   IsNumber,
   IsOptional,
   IsString,
-  IsUrl,
   IsUUID,
   MaxLength,
   Min,
@@ -44,16 +43,14 @@ export class CreateProductDto {
   price: number;
 
   @IsOptional()
-  @IsString({ message: 'A URL da imagem deve ser uma string.' })
-  @IsUrl({}, { message: 'A URL da imagem não é válida.' })
+  @IsString({ message: 'A imagem deve ser uma string.' })
   @MaxLength(255, {
-    message: 'A URL da imagem não pode ter mais de 255 caracteres.',
+    message: 'A imagem não pode ter mais de 255 caracteres.',
   })
   imageUrl?: string;
 
   @IsOptional()
   @IsString({ message: 'A hash da imagem deve ser uma string.' })
-  @IsUrl({}, { message: 'A hash da imagem não é válida.' })
   @MaxLength(255, {
     message: 'A hash da imagem não pode ter mais de 255 caracteres.',
   })

--- a/api/src/modules/products/dto/update-product.dto.ts
+++ b/api/src/modules/products/dto/update-product.dto.ts
@@ -5,7 +5,6 @@ import {
   IsNumber,
   IsOptional,
   IsString,
-  IsUrl,
   IsUUID,
   MaxLength,
   Min,
@@ -41,16 +40,14 @@ export class UpdateProductDto extends PartialType(CreateProductDto) {
   price?: number;
 
   @IsOptional()
-  @IsString({ message: 'A URL da imagem deve ser uma string.' })
-  @IsUrl({}, { message: 'A URL da imagem não é válida.' })
+  @IsString({ message: 'A imagem deve ser uma string.' })
   @MaxLength(255, {
-    message: 'A URL da imagem não pode ter mais de 255 caracteres.',
+    message: 'A imagem não pode ter mais de 255 caracteres.',
   })
   imageUrl?: string;
 
   @IsOptional()
   @IsString({ message: 'A hash da imagem deve ser uma string.' })
-  @IsUrl({}, { message: 'A hash da imagem não é válida.' })
   @MaxLength(255, {
     message: 'A hash da imagem não pode ter mais de 255 caracteres.',
   })

--- a/api/src/modules/products/products.controller.ts
+++ b/api/src/modules/products/products.controller.ts
@@ -62,8 +62,8 @@ export class ProductsController {
     @Body() updateProductDto: UpdateProductDto,
     @UploadedFile() file: Express.Multer.File,
   ): Promise<Product> {
-    if (!updateProductDto) {
-      throw new BadRequestException('Dados de atualização não foram enviados.');
+    if (!updateProductDto || Object.keys(updateProductDto).length === 0) {
+      throw new BadRequestException('Nenhum dado de atualização foi enviado.');
     }
 
     if (file?.path) {


### PR DESCRIPTION
Removidas as validações que exigiam URL nas imagens, o que impedia o upload com arquivos locais. Agora é possível enviar a imagem normalmente com multer, processar com sharp e fazer o upload pro Cloudinary sem erro 400.