### PR TITLE
Corrige update de produto para aceitar apenas arquivo de imagem no multipart/form-data

### DIFF
--- a/api/src/modules/products/products.controller.spec.ts
+++ b/api/src/modules/products/products.controller.spec.ts
@@ -111,9 +111,9 @@ describe('ProductsController', () => {
 
   describe('update', () => {
     it('should throw BadRequestException if updateProductDto is missing', async () => {
-      await expect(controller.update('1', null, null)).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(
+        controller.update('1', undefined, undefined),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('should update product and set imageUrl relative path if file provided', async () => {

--- a/api/src/modules/products/products.controller.ts
+++ b/api/src/modules/products/products.controller.ts
@@ -62,7 +62,10 @@ export class ProductsController {
     @Body() updateProductDto: UpdateProductDto,
     @UploadedFile() file: Express.Multer.File,
   ): Promise<Product> {
-    if (!file && Object.keys(updateProductDto).length === 0) {
+    if (
+      !updateProductDto ||
+      (Object.keys(updateProductDto).length === 0 && !file)
+    ) {
       throw new BadRequestException('Nenhum dado de atualização foi enviado.');
     }
 

--- a/api/src/modules/products/products.controller.ts
+++ b/api/src/modules/products/products.controller.ts
@@ -62,7 +62,7 @@ export class ProductsController {
     @Body() updateProductDto: UpdateProductDto,
     @UploadedFile() file: Express.Multer.File,
   ): Promise<Product> {
-    if (!updateProductDto || Object.keys(updateProductDto).length === 0) {
+    if (!file && Object.keys(updateProductDto).length === 0) {
       throw new BadRequestException('Nenhum dado de atualização foi enviado.');
     }
 


### PR DESCRIPTION
Este PR ajusta o endpoint de atualização de produto para corrigir o erro 400 quando a requisição contém apenas um arquivo de imagem (campo 'imageUrl') e nenhum dado no corpo da requisição.

Agora, o backend valida corretamente se pelo menos um arquivo ou dados foram enviados, permitindo atualizar somente a imagem sem precisar enviar outros campos.

Esse ajuste garante compatibilidade com testes via Postman usando form-data apenas com o arquivo, evitando erro de "Nenhum dado de atualização foi enviado".
