### PR TITLE
Corrige validação no update do produto para tratar dados de atualização ausentes

### DIFF
--- a/api/src/modules/products/products.controller.ts
+++ b/api/src/modules/products/products.controller.ts
@@ -63,8 +63,8 @@ export class ProductsController {
     @UploadedFile() file: Express.Multer.File,
   ): Promise<Product> {
     if (
-      !updateProductDto ||
-      (Object.keys(updateProductDto).length === 0 && !file)
+      !file &&
+      (!updateProductDto || Object.keys(updateProductDto).length === 0)
     ) {
       throw new BadRequestException('Nenhum dado de atualização foi enviado.');
     }

--- a/api/src/modules/products/products.service.ts
+++ b/api/src/modules/products/products.service.ts
@@ -223,9 +223,6 @@ export class ProductsService {
     if (product.imageDeleteHash) {
       try {
         await this.cloudinaryService.deleteImage(product.imageDeleteHash);
-        console.log(
-          `Imagem com ID ${product.imageId} removida com sucesso do Imgur.`,
-        );
       } catch (error) {
         console.error('Erro ao excluir imagem do Imgur:', error.message);
       }


### PR DESCRIPTION
Esse PR corrige a validação do endpoint de atualização do produto, tratando corretamente o caso em que o corpo da requisição (updateProductDto) não é enviado ou é undefined. Agora, o código verifica a existência do DTO antes de acessar suas propriedades, evitando erro 500 ou 400 inesperado.

Além disso, essa alteração prepara a API para receber requisições com ou sem arquivo de imagem, sem quebrar a validação, melhorando a robustez da aplicação.