### PR TITLE
Corrige tentativa de exclusão de URLs de imagem remota no FileService

### DIFF
--- a/api/src/shared/utils/file.service.ts
+++ b/api/src/shared/utils/file.service.ts
@@ -7,12 +7,23 @@ import * as path from 'path';
 export class FileService {
   private readonly logger = new Logger(FileService.name);
 
+  private isRemoteUrl(filePath: string): boolean {
+    return filePath.startsWith('http://') || filePath.startsWith('https://');
+  }
+
   // Deletar o arquivo
   async deleteFileIfExists(filePath: string): Promise<void> {
+    if (this.isRemoteUrl(filePath)) {
+      this.logger.warn(
+        `⚠️ Tentativa de deletar uma URL externa ignorada: ${filePath}`,
+      );
+      return;
+    }
+
     const relativePath = path.relative(process.cwd(), filePath);
     try {
       await unlink(filePath);
-      this.logger.log(`Arquivo deletado com sucesso: ${relativePath}`);
+      this.logger.log(`🗑️ Arquivo deletado com sucesso: ${relativePath}`);
     } catch (error) {
       this.logger.warn(
         `⚠️ Não foi possível deletar o arquivo: ${relativePath}`,


### PR DESCRIPTION
Este PR ajusta o método `deleteFileIfExists` para evitar a tentativa de deletar arquivos remotos (como URLs do Cloudinary). Agora o método verifica se o caminho é uma URL externa antes de usar `unlink`, prevenindo erros do tipo ENOENT e garantindo que apenas arquivos locais sejam deletados.

Melhoria importante para ambientes com imagens hospedadas remotamente, evitando logs de erro desnecessários e falhas silenciosas.