### PR TITLE
Corrige troca entre chave e segredo da API do Cloudinary

### DIFF
--- a/api/src/modules/products/products.service.ts
+++ b/api/src/modules/products/products.service.ts
@@ -230,7 +230,7 @@ export class ProductsService {
       try {
         await this.cloudinaryService.deleteImage(product.imageDeleteHash);
       } catch (error) {
-        console.error('Erro ao excluir imagem do Imgur:', error.message);
+        console.error('Erro ao excluir imagem do Cloudinary:', error.message);
       }
     }
 

--- a/api/src/shared/config/config.service.ts
+++ b/api/src/shared/config/config.service.ts
@@ -97,10 +97,10 @@ export class ConfigService {
   }
 
   get cloudinaryApiSecret(): string {
-    return this.config.CLOUDINARY_API_KEY;
+    return this.config.CLOUDINARY_API_SECRET;
   }
 
   get cloudinaryApiKey(): string {
-    return this.config.CLOUDINARY_API_SECRET;
+    return this.config.CLOUDINARY_API_KEY;
   }
 }


### PR DESCRIPTION
Este PR corrige um problema na classe `ConfigService` onde as variáveis `CLOUDINARY_API_KEY` e `CLOUDINARY_API_SECRET` estavam trocadas, o que causava falha de autenticação ao tentar deletar imagens usando o SDK do Cloudinary.

- Atribuições corrigidas no mapeamento das variáveis de ambiente
- Autenticação do Cloudinary agora deve funcionar corretamente tanto para upload quanto para remoção
