### PR TITLE
Refatoração no serviço de produtos para evitar tentativa de deleção de URLs externas

### DIFF
--- a/api/src/modules/products/products.service.ts
+++ b/api/src/modules/products/products.service.ts
@@ -199,7 +199,7 @@ export class ProductsService {
           await this.cloudinaryService.deleteImage(oldImageDeleteHash);
         }
 
-        if (oldImageUrl) {
+        if (oldImageUrl && !oldImageUrl.startsWith('http')) {
           await this.fileService.deleteFileIfExists(oldImageUrl);
         }
       } catch (error) {


### PR DESCRIPTION
Esta PR ajusta o método de deleção de arquivos do serviço de produtos para evitar erros ao tentar deletar imagens que estão hospedadas externamente (ex: Cloudinary).